### PR TITLE
janky preview render

### DIFF
--- a/src/Evergreen/Migrate/V21.elm
+++ b/src/Evergreen/Migrate/V21.elm
@@ -1,0 +1,112 @@
+module Evergreen.Migrate.V21 exposing (..)
+
+import Dict
+import Evergreen.V19.Api.Card as OldCard exposing (CardEnvelope, FlashCard(..))
+import Evergreen.V19.Api.User
+import Evergreen.V19.Types as Old
+import Evergreen.V21.Api.Card as NewCard exposing (FlashCard(..))
+import Evergreen.V21.Api.User
+import Evergreen.V21.Types as New
+import Lamdera.Migrations exposing (..)
+
+
+frontendModel : Old.FrontendModel -> ModelMigration New.FrontendModel New.FrontendMsg
+frontendModel old =
+    ModelUnchanged
+
+
+backendModel : Old.BackendModel -> ModelMigration New.BackendModel New.BackendMsg
+backendModel old =
+    let
+        migrateSession : Old.Session -> New.Session
+        migrateSession old_ =
+            { userId = old_.userId
+            , expires = old_.expires
+            }
+
+        migrateUser : Evergreen.V19.Api.User.UserFull -> Evergreen.V21.Api.User.UserFull
+        migrateUser old_ =
+            { id = old_.id
+            , email = old_.email
+            , username = old_.username
+            , bio = old_.bio
+            , image = old_.image
+            , password = old_.password
+            }
+
+        migrateCard : OldCard.CardEnvelope -> NewCard.CardEnvelope
+        migrateCard old_ =
+            { id = old_.id
+            , card =
+                case old_.card of
+                    OldCard.PlainText card ->
+                        NewCard.PlainText card
+
+                    OldCard.Markdown card ->
+                        NewCard.Markdown card
+            , userId = old_.userId
+            , createdAt = old_.createdAt
+            , lastModifiedOn = old_.lastModifiedOn
+            , nextPromptSchedFor = old_.nextPromptSchedFor
+            , frequency =
+                case old_.frequency of
+                    OldCard.Immediately ->
+                        NewCard.Immediately
+
+                    OldCard.OneDay ->
+                        NewCard.OneDay
+
+                    OldCard.TwoDays ->
+                        NewCard.TwoDays
+
+                    OldCard.SevenDays ->
+                        NewCard.SevenDays
+
+                    OldCard.FourteenDays ->
+                        NewCard.FourteenDays
+
+                    OldCard.ThirtyDays ->
+                        NewCard.ThirtyDays
+            }
+
+        sessions =
+            Dict.map (\k s -> migrateSession s) old.sessions
+
+        users =
+            Dict.map (\k u -> migrateUser u) old.users
+
+        cards =
+            Dict.map (\k c -> migrateCard c) old.cards
+
+        now =
+            old.now
+    in
+    ModelMigrated
+        ( { sessions = sessions
+          , users = users
+          , cards = cards
+          , now = now
+          , nextCardId = 1000
+          }
+        , Cmd.none
+        )
+
+
+frontendMsg : Old.FrontendMsg -> MsgMigration New.FrontendMsg New.FrontendMsg
+frontendMsg old =
+    MsgOldValueIgnored
+
+
+toBackend : Old.ToBackend -> MsgMigration New.ToBackend New.BackendMsg
+toBackend old =
+    MsgOldValueIgnored
+
+
+backendMsg : Old.BackendMsg -> MsgMigration New.BackendMsg New.BackendMsg
+backendMsg old =
+    MsgOldValueIgnored
+
+
+toFrontend : Old.ToFrontend -> MsgMigration New.ToFrontend New.FrontendMsg
+toFrontend old =
+    MsgOldValueIgnored

--- a/src/Evergreen/V21/Api/Card.elm
+++ b/src/Evergreen/V21/Api/Card.elm
@@ -1,0 +1,59 @@
+module Evergreen.V21.Api.Card exposing (..)
+
+import Evergreen.V21.Api.User
+import Time
+
+
+type alias PlainTextCard =
+    { question : String
+    , answer : String
+    }
+
+
+type alias MarkdownCard =
+    { question : String
+    , renderedQuestion : String
+    , answer : String
+    , renderedAnswer : String
+    , tags : List String
+    }
+
+
+type alias CardId =
+    Int
+
+
+type FlashCard
+    = PlainText PlainTextCard
+    | Markdown MarkdownCard
+
+
+type PromptFrequency
+    = Immediately
+    | OneDay
+    | TwoDays
+    | SevenDays
+    | FourteenDays
+    | ThirtyDays
+
+
+type alias CardEnvelope =
+    { id : CardId
+    , card : FlashCard
+    , userId : Evergreen.V21.Api.User.UserId
+    , createdAt : Time.Posix
+    , lastModifiedOn : Time.Posix
+    , nextPromptSchedFor : Time.Posix
+    , frequency : PromptFrequency
+    }
+
+
+type alias StudySessionSummary =
+    { usersTotalCardCount : Int
+    , cardsToStudy : Int
+    }
+
+
+type Grade
+    = Correct
+    | Incorrect

--- a/src/Evergreen/V21/Api/Data.elm
+++ b/src/Evergreen/V21/Api/Data.elm
@@ -1,0 +1,8 @@
+module Evergreen.V21.Api.Data exposing (..)
+
+
+type Data value
+    = NotAsked
+    | Loading
+    | Failure (List String)
+    | Success value

--- a/src/Evergreen/V21/Api/Profile.elm
+++ b/src/Evergreen/V21/Api/Profile.elm
@@ -1,0 +1,9 @@
+module Evergreen.V21.Api.Profile exposing (..)
+
+
+type alias Profile =
+    { username : String
+    , bio : Maybe String
+    , image : String
+    , following : Bool
+    }

--- a/src/Evergreen/V21/Api/User.elm
+++ b/src/Evergreen/V21/Api/User.elm
@@ -1,0 +1,28 @@
+module Evergreen.V21.Api.User exposing (..)
+
+
+type alias Email =
+    String
+
+
+type alias User =
+    { id : Int
+    , email : Email
+    , username : String
+    , bio : Maybe String
+    , image : String
+    }
+
+
+type alias UserId =
+    Int
+
+
+type alias UserFull =
+    { id : Int
+    , email : Email
+    , username : String
+    , bio : Maybe String
+    , image : String
+    , password : String
+    }

--- a/src/Evergreen/V21/Bridge.elm
+++ b/src/Evergreen/V21/Bridge.elm
@@ -1,0 +1,39 @@
+module Evergreen.V21.Bridge exposing (..)
+
+import Evergreen.V21.Api.Card
+import Evergreen.V21.Api.User
+
+
+type ToBackend
+    = SignedOut Evergreen.V21.Api.User.User
+    | ProfileGet_Profile__Username_
+        { username : String
+        }
+    | UserAuthentication_Login
+        { params :
+            { email : String
+            , password : String
+            }
+        }
+    | UserRegistration_Register
+        { params :
+            { username : String
+            , email : String
+            , password : String
+            }
+        }
+    | UserUpdate_Settings
+        { params :
+            { username : String
+            , email : String
+            , password : Maybe String
+            , image : String
+            , bio : String
+            }
+        }
+    | CreateCard_Cards Evergreen.V21.Api.Card.FlashCard Evergreen.V21.Api.User.UserId
+    | FetchUsersStudyCards_Study Evergreen.V21.Api.User.User
+    | FetchUsersStudySummary_Study Evergreen.V21.Api.User.User
+    | UserSubmitGrade_Study Evergreen.V21.Api.Card.CardId Evergreen.V21.Api.Card.Grade
+    | FetchUsersCatalog_Catalog Evergreen.V21.Api.User.User
+    | DeleteCard_Catalog Evergreen.V21.Api.Card.CardId Evergreen.V21.Api.User.UserId

--- a/src/Evergreen/V21/Gen/Model.elm
+++ b/src/Evergreen/V21/Gen/Model.elm
@@ -1,0 +1,33 @@
+module Evergreen.V21.Gen.Model exposing (..)
+
+import Evergreen.V21.Gen.Params.Cards
+import Evergreen.V21.Gen.Params.Catalog
+import Evergreen.V21.Gen.Params.Home_
+import Evergreen.V21.Gen.Params.Login
+import Evergreen.V21.Gen.Params.NotFound
+import Evergreen.V21.Gen.Params.Profile.Username_
+import Evergreen.V21.Gen.Params.Register
+import Evergreen.V21.Gen.Params.Settings
+import Evergreen.V21.Gen.Params.Study
+import Evergreen.V21.Pages.Cards
+import Evergreen.V21.Pages.Catalog
+import Evergreen.V21.Pages.Home_
+import Evergreen.V21.Pages.Login
+import Evergreen.V21.Pages.NotFound
+import Evergreen.V21.Pages.Profile.Username_
+import Evergreen.V21.Pages.Register
+import Evergreen.V21.Pages.Settings
+import Evergreen.V21.Pages.Study
+
+
+type Model
+    = Redirecting_
+    | Cards Evergreen.V21.Gen.Params.Cards.Params Evergreen.V21.Pages.Cards.Model
+    | Catalog Evergreen.V21.Gen.Params.Catalog.Params Evergreen.V21.Pages.Catalog.Model
+    | Home_ Evergreen.V21.Gen.Params.Home_.Params Evergreen.V21.Pages.Home_.Model
+    | Login Evergreen.V21.Gen.Params.Login.Params Evergreen.V21.Pages.Login.Model
+    | NotFound Evergreen.V21.Gen.Params.NotFound.Params Evergreen.V21.Pages.NotFound.Model
+    | Register Evergreen.V21.Gen.Params.Register.Params Evergreen.V21.Pages.Register.Model
+    | Settings Evergreen.V21.Gen.Params.Settings.Params Evergreen.V21.Pages.Settings.Model
+    | Study Evergreen.V21.Gen.Params.Study.Params Evergreen.V21.Pages.Study.Model
+    | Profile__Username_ Evergreen.V21.Gen.Params.Profile.Username_.Params Evergreen.V21.Pages.Profile.Username_.Model

--- a/src/Evergreen/V21/Gen/Msg.elm
+++ b/src/Evergreen/V21/Gen/Msg.elm
@@ -1,0 +1,23 @@
+module Evergreen.V21.Gen.Msg exposing (..)
+
+import Evergreen.V21.Pages.Cards
+import Evergreen.V21.Pages.Catalog
+import Evergreen.V21.Pages.Home_
+import Evergreen.V21.Pages.Login
+import Evergreen.V21.Pages.NotFound
+import Evergreen.V21.Pages.Profile.Username_
+import Evergreen.V21.Pages.Register
+import Evergreen.V21.Pages.Settings
+import Evergreen.V21.Pages.Study
+
+
+type Msg
+    = Cards Evergreen.V21.Pages.Cards.Msg
+    | Catalog Evergreen.V21.Pages.Catalog.Msg
+    | Home_ Evergreen.V21.Pages.Home_.Msg
+    | Login Evergreen.V21.Pages.Login.Msg
+    | NotFound Evergreen.V21.Pages.NotFound.Msg
+    | Register Evergreen.V21.Pages.Register.Msg
+    | Settings Evergreen.V21.Pages.Settings.Msg
+    | Study Evergreen.V21.Pages.Study.Msg
+    | Profile__Username_ Evergreen.V21.Pages.Profile.Username_.Msg

--- a/src/Evergreen/V21/Gen/Pages.elm
+++ b/src/Evergreen/V21/Gen/Pages.elm
@@ -1,0 +1,12 @@
+module Evergreen.V21.Gen.Pages exposing (..)
+
+import Evergreen.V21.Gen.Model
+import Evergreen.V21.Gen.Msg
+
+
+type alias Model =
+    Evergreen.V21.Gen.Model.Model
+
+
+type alias Msg =
+    Evergreen.V21.Gen.Msg.Msg

--- a/src/Evergreen/V21/Gen/Params/Cards.elm
+++ b/src/Evergreen/V21/Gen/Params/Cards.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Cards exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Catalog.elm
+++ b/src/Evergreen/V21/Gen/Params/Catalog.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Catalog exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Home_.elm
+++ b/src/Evergreen/V21/Gen/Params/Home_.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Home_ exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Login.elm
+++ b/src/Evergreen/V21/Gen/Params/Login.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Login exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/NotFound.elm
+++ b/src/Evergreen/V21/Gen/Params/NotFound.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.NotFound exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Profile/Username_.elm
+++ b/src/Evergreen/V21/Gen/Params/Profile/Username_.elm
@@ -1,0 +1,6 @@
+module Evergreen.V21.Gen.Params.Profile.Username_ exposing (..)
+
+
+type alias Params =
+    { username : String
+    }

--- a/src/Evergreen/V21/Gen/Params/Register.elm
+++ b/src/Evergreen/V21/Gen/Params/Register.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Register exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Settings.elm
+++ b/src/Evergreen/V21/Gen/Params/Settings.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Settings exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Gen/Params/Study.elm
+++ b/src/Evergreen/V21/Gen/Params/Study.elm
@@ -1,0 +1,5 @@
+module Evergreen.V21.Gen.Params.Study exposing (..)
+
+
+type alias Params =
+    ()

--- a/src/Evergreen/V21/Pages/Cards.elm
+++ b/src/Evergreen/V21/Pages/Cards.elm
@@ -1,0 +1,39 @@
+module Evergreen.V21.Pages.Cards exposing (..)
+
+import Evergreen.V21.Api.Card
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.User
+import Markdown.Render
+
+
+type SelectedFormRadioOption
+    = MarkdownRadioOption
+    | PlainTextRadioOption
+
+
+type EditorForm
+    = PlainTextForm Evergreen.V21.Api.Card.PlainTextCard
+    | MarkdownForm Evergreen.V21.Api.Card.MarkdownCard
+
+
+type alias Model =
+    { selectedOption : SelectedFormRadioOption
+    , editorForm : EditorForm
+    , cardSubmitStatus : Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Card.CardId
+    , user : Evergreen.V21.Api.User.User
+    }
+
+
+type EditorField
+    = PlainText_Question
+    | PlainText_Answer
+    | Markdown_Question
+    | Markdown_Answer
+
+
+type Msg
+    = Updated EditorForm EditorField String
+    | ToggledOption SelectedFormRadioOption
+    | Submitted Evergreen.V21.Api.Card.FlashCard Evergreen.V21.Api.User.UserId
+    | GotCard (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Card.CardId)
+    | MarkdownMsg Markdown.Render.MarkdownMsg

--- a/src/Evergreen/V21/Pages/Catalog.elm
+++ b/src/Evergreen/V21/Pages/Catalog.elm
@@ -1,0 +1,29 @@
+module Evergreen.V21.Pages.Catalog exposing (..)
+
+import Evergreen.V21.Api.Card
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.User
+import Markdown.Render
+import Time
+
+
+type alias Model =
+    { user : Maybe Evergreen.V21.Api.User.User
+    , zone : Time.Zone
+    , wiredCards : Evergreen.V21.Api.Data.Data (List Evergreen.V21.Api.Card.CardEnvelope)
+    , selectedEnv : Maybe Evergreen.V21.Api.Card.CardEnvelope
+    , hoveredOnEnv : Maybe Evergreen.V21.Api.Card.CardEnvelope
+    , deletedCardId : Maybe Evergreen.V21.Api.Card.CardId
+    }
+
+
+type Msg
+    = FetchUserCatalog Evergreen.V21.Api.User.User
+    | GotUserCatalog (Evergreen.V21.Api.Data.Data (List Evergreen.V21.Api.Card.CardEnvelope))
+    | GotDeleteCardResponse Evergreen.V21.Api.Card.CardId
+    | UserSelectedCard Evergreen.V21.Api.Card.CardEnvelope
+    | UserClickedDelete Evergreen.V21.Api.Card.CardId Evergreen.V21.Api.User.UserId
+    | UserMousesOver Evergreen.V21.Api.Card.CardEnvelope
+    | ClearTableHover
+    | MarkdownMsg Markdown.Render.MarkdownMsg
+    | Noop

--- a/src/Evergreen/V21/Pages/Home_.elm
+++ b/src/Evergreen/V21/Pages/Home_.elm
@@ -1,0 +1,14 @@
+module Evergreen.V21.Pages.Home_ exposing (..)
+
+
+type Tab
+    = Global
+
+
+type alias Model =
+    { tab : Tab
+    }
+
+
+type Msg
+    = Noop

--- a/src/Evergreen/V21/Pages/Login.elm
+++ b/src/Evergreen/V21/Pages/Login.elm
@@ -1,0 +1,22 @@
+module Evergreen.V21.Pages.Login exposing (..)
+
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.User
+
+
+type alias Model =
+    { user : Evergreen.V21.Api.Data.Data Evergreen.V21.Api.User.User
+    , email : String
+    , password : String
+    }
+
+
+type Field
+    = Email
+    | Password
+
+
+type Msg
+    = Updated Field String
+    | AttemptedSignIn
+    | GotUser (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.User.User)

--- a/src/Evergreen/V21/Pages/NotFound.elm
+++ b/src/Evergreen/V21/Pages/NotFound.elm
@@ -1,0 +1,9 @@
+module Evergreen.V21.Pages.NotFound exposing (..)
+
+
+type alias Model =
+    {}
+
+
+type Msg
+    = ReplaceMe

--- a/src/Evergreen/V21/Pages/Profile/Username_.elm
+++ b/src/Evergreen/V21/Pages/Profile/Username_.elm
@@ -1,0 +1,21 @@
+module Evergreen.V21.Pages.Profile.Username_ exposing (..)
+
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.Profile
+
+
+type Tab
+    = MyArticles
+    | FavoritedArticles
+
+
+type alias Model =
+    { username : String
+    , profile : Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Profile.Profile
+    , selectedTab : Tab
+    , page : Int
+    }
+
+
+type Msg
+    = GotProfile (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Profile.Profile)

--- a/src/Evergreen/V21/Pages/Register.elm
+++ b/src/Evergreen/V21/Pages/Register.elm
@@ -1,0 +1,24 @@
+module Evergreen.V21.Pages.Register exposing (..)
+
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.User
+
+
+type alias Model =
+    { user : Evergreen.V21.Api.Data.Data Evergreen.V21.Api.User.User
+    , displayName : String
+    , email : String
+    , password : String
+    }
+
+
+type Field
+    = Username
+    | Email
+    | Password
+
+
+type Msg
+    = Updated Field String
+    | AttemptedSignUp
+    | GotUser (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.User.User)

--- a/src/Evergreen/V21/Pages/Settings.elm
+++ b/src/Evergreen/V21/Pages/Settings.elm
@@ -1,0 +1,29 @@
+module Evergreen.V21.Pages.Settings exposing (..)
+
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.User
+
+
+type alias Model =
+    { image : String
+    , username : String
+    , bio : String
+    , email : String
+    , password : Maybe String
+    , message : Maybe String
+    , errors : List String
+    }
+
+
+type Field
+    = Image
+    | Username
+    | Bio
+    | Email
+    | Password
+
+
+type Msg
+    = Updated Field String
+    | SubmittedForm Evergreen.V21.Api.User.User
+    | GotUser (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.User.User)

--- a/src/Evergreen/V21/Pages/Study.elm
+++ b/src/Evergreen/V21/Pages/Study.elm
@@ -1,0 +1,32 @@
+module Evergreen.V21.Pages.Study exposing (..)
+
+import Evergreen.V21.Api.Card
+import Evergreen.V21.Api.Data
+import Evergreen.V21.Api.User
+import Markdown.Render
+
+
+type PromptStatus
+    = Idle
+    | QuestionPrompted
+    | AnswerRevealed
+
+
+type alias Model =
+    { cardDataFetch : Evergreen.V21.Api.Data.Data (List Evergreen.V21.Api.Card.CardEnvelope)
+    , promptStatus : PromptStatus
+    , gradeSubmit : Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Card.CardId
+    , sessionSummary : Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Card.StudySessionSummary
+    , user : Maybe Evergreen.V21.Api.User.User
+    }
+
+
+type Msg
+    = FetchCards Evergreen.V21.Api.User.User
+    | GotUserCards (Evergreen.V21.Api.Data.Data (List Evergreen.V21.Api.Card.CardEnvelope))
+    | UserClickedReveal
+    | UserSelfGrade Evergreen.V21.Api.Card.CardId Evergreen.V21.Api.Card.Grade
+    | GotGradedResponse (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Card.CardId)
+    | GotStudySessionSummary (Evergreen.V21.Api.Data.Data Evergreen.V21.Api.Card.StudySessionSummary)
+    | UserStartStudySession
+    | MarkdownMsg Markdown.Render.MarkdownMsg

--- a/src/Evergreen/V21/Shared.elm
+++ b/src/Evergreen/V21/Shared.elm
@@ -1,0 +1,16 @@
+module Evergreen.V21.Shared exposing (..)
+
+import Evergreen.V21.Api.User
+import Time
+
+
+type alias Model =
+    { user : Maybe Evergreen.V21.Api.User.User
+    , zone : Time.Zone
+    }
+
+
+type Msg
+    = ClickedSignOut
+    | SignedInUser Evergreen.V21.Api.User.User
+    | SetTimeZoneToLocale Time.Zone

--- a/src/Evergreen/V21/Types.elm
+++ b/src/Evergreen/V21/Types.elm
@@ -1,0 +1,62 @@
+module Evergreen.V21.Types exposing (..)
+
+import Browser
+import Browser.Navigation
+import Dict
+import Evergreen.V21.Api.Card
+import Evergreen.V21.Api.User
+import Evergreen.V21.Bridge
+import Evergreen.V21.Gen.Pages
+import Evergreen.V21.Shared
+import Lamdera
+import Time
+import Url
+
+
+type alias FrontendModel =
+    { url : Url.Url
+    , key : Browser.Navigation.Key
+    , shared : Evergreen.V21.Shared.Model
+    , page : Evergreen.V21.Gen.Pages.Model
+    }
+
+
+type alias Session =
+    { userId : Int
+    , expires : Time.Posix
+    }
+
+
+type alias BackendModel =
+    { sessions : Dict.Dict Lamdera.SessionId Session
+    , users : Dict.Dict Int Evergreen.V21.Api.User.UserFull
+    , cards : Dict.Dict Evergreen.V21.Api.Card.CardId Evergreen.V21.Api.Card.CardEnvelope
+    , now : Time.Posix
+    , nextCardId : Int
+    }
+
+
+type FrontendMsg
+    = ChangedUrl Url.Url
+    | ClickedLink Browser.UrlRequest
+    | Shared Evergreen.V21.Shared.Msg
+    | Page Evergreen.V21.Gen.Pages.Msg
+    | Noop
+
+
+type alias ToBackend =
+    Evergreen.V21.Bridge.ToBackend
+
+
+type BackendMsg
+    = CheckSession Lamdera.SessionId Lamdera.ClientId
+    | RenewSession Evergreen.V21.Api.User.UserId Lamdera.SessionId Lamdera.ClientId Time.Posix
+    | NoOpBackendMsg
+    | Tick Time.Posix
+    | IncrementCardId
+
+
+type ToFrontend
+    = ActiveSession Evergreen.V21.Api.User.User
+    | PageMsg Evergreen.V21.Gen.Pages.Msg
+    | NoOpToFrontend

--- a/src/Pages/Cards.elm
+++ b/src/Pages/Cards.elm
@@ -225,8 +225,8 @@ viewElements model =
             , centerX
             ]
             [ viewCardTypeSelector model
-            , viewCardSubmission model.editorForm model.user
             , viewCardSubmitStatus model
+            , viewCardSubmission model.editorForm model.user
             ]
         , E.column
             [ E.width <| E.minimum 600 fill
@@ -293,7 +293,7 @@ viewCardSubmitStatus model =
             E.column [] <| List.map (\e -> E.text e) errs
 
         Success cardId ->
-            E.text <| "Success, there are " ++ String.fromInt cardId ++ " cards"
+            E.text <| "Success"
 
 
 viewCardTypeSelector : Model -> Element Msg

--- a/src/Pages/Study.elm
+++ b/src/Pages/Study.elm
@@ -319,6 +319,15 @@ viewElements model =
                         nCards =
                             List.length cards
 
+                        currentCardText : String
+                        currentCardText =
+                            case List.head cards of
+                                Nothing ->
+                                    " "
+
+                                Just card ->
+                                    "DEBUG: Selected cardId=" ++ String.fromInt card.id
+
                         cardCopy =
                             if nCards == 1 then
                                 "card"
@@ -326,7 +335,7 @@ viewElements model =
                             else
                                 "cards"
                     in
-                    "You have " ++ String.fromInt nCards ++ " " ++ cardCopy ++ " due for study."
+                    "You have " ++ String.fromInt nCards ++ " " ++ cardCopy ++ " due for study.     " ++ currentCardText
     in
     column
         [ width fill
@@ -339,7 +348,7 @@ viewElements model =
             , Background.color Styling.softGrey
             , height <| px 50
             ]
-            (el [ centerY ] <| text summaryText)
+            (el [ centerY, alignLeft ] <| text summaryText)
         , el
             [ width fill
             , height fill

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,8 +1,8 @@
 module Types exposing (..)
 
+import Api.Card exposing (CardEnvelope, CardId, FlashCard)
 import Api.User exposing (User, UserFull, UserId)
 import Bridge
-import Api.Card exposing (FlashCard, CardId, CardEnvelope)
 import Browser
 import Browser.Navigation exposing (Key)
 import Dict exposing (Dict)
@@ -32,11 +32,13 @@ type FrontendMsg
     | Page Pages.Msg
     | Noop
 
+
 type alias BackendModel =
     { sessions : Dict SessionId Session
     , users : Dict Int UserFull
     , cards : Dict CardId CardEnvelope
     , now : Time.Posix
+    , nextCardId : Int
     }
 
 
@@ -49,6 +51,7 @@ type BackendMsg
     | RenewSession UserId SessionId ClientId Time.Posix
     | NoOpBackendMsg
     | Tick Time.Posix
+    | IncrementCardId
 
 
 type ToFrontend


### PR DESCRIPTION
Adds a prompt preview on the catalog page, which led me to discover a bug.

To date I was assigning a new card's id by inspecting the size of the backend catalog, and adding one. Now that deletion is supported, this no longer works. Solution:
 * nextCardId belongs to Backend model
 * creating a card increments nextCardId
 * one-time initialization of this cardId to 1000, prevents trampling existing cards

This solution isn't perfect, as the cardId counter is not atomic, and is therefore subject to race conditions. In practice, I don't think this will be an issue, and I am likely the only person to ever use this app.