### PR TITLE
Revert "updating lamdera fixed local dev issues"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:current-buster
+
+RUN apt-get update
+
+#  This is here bc I was getting the following upon `lamdera init`: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory          
+RUN apt install -y \
+    libtinfo5 
+
+# Install lamdera refer to: https://dashboard.lamdera.app/docs/download
+RUN curl https://static.lamdera.com/bin/linux/lamdera -o /usr/local/bin/lamdera
+RUN chmod a+x /usr/local/bin/lamdera

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,46 @@
+version: "3.3"
+
+services:
+  bash:
+    image: hippo-lamdera:dev
+    networks:
+      - hippo-lamdera-network
+    working_dir: /root/code
+    volumes:
+      - .:/root/code
+    command: bash
+
+  dev:
+    ports:
+      - 8000:8000
+    container_name: hippo-lamdera
+    image: hippo-lamdera:dev
+    networks:
+      - hippo-lamdera-network
+    stdin_open: true
+    tty: true
+    working_dir: /root/code
+    volumes:
+      - .:/root/code
+    command: lamdera live
+
+  check:
+    image: hippo-lamdera:dev
+    networks:
+      - hippo-lamdera-network
+    working_dir: /root/code
+    volumes:
+      - .:/root/code
+    command: lamdera check
+  
+  generate_test_data:
+    image: dev-kit:latest
+    volumes:
+      - .:/home/appuser/workspace
+    command: python ./shell-scripts/generate_test_data.py
+
+networks:
+  hippo-lamdera-network:
+    driver: bridge
+    ipam:
+      driver: default

--- a/shell-scripts/build.sh
+++ b/shell-scripts/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t hippo-lamdera:dev .

--- a/shell-scripts/generate_test_data.py
+++ b/shell-scripts/generate_test_data.py
@@ -1,0 +1,8 @@
+
+
+def run():
+    print("Hello!")
+
+
+if __name__ == "__main__":
+    run()

--- a/shell-scripts/ref.md
+++ b/shell-scripts/ref.md
@@ -1,0 +1,12 @@
+This is a dev reference file for things needed to build stuff but aren't frequent enough to automate
+
+
+adding a page via `elm-spa`:
+
+In Windows git console, not vs-code console (not sure why)
+
+To add `/example_route` to the app do:
+```bash
+elm-spa add example_route element
+elm-spa gen
+```


### PR DESCRIPTION
Reverts project-fir/hippo-lamdera#37, turns out docker is still useful for local-network testing, which is good for testing things on phones.